### PR TITLE
Add 1m interval and HTML stats output

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,18 @@
 
 GO Monitoring Service for VM. The service collects CPU and memory usage of the
 host and exposes a `/stats` HTTP endpoint. The endpoint returns the maximum CPU
-percentage and memory usage (in MB) observed over the last 5 minutes, 1 hour and
-24 hours in the following format:
+percentage and memory usage (in MB) observed over the last 1 minute, 5 minutes,
+1 hour and 24 hours in the following format:
 
 ```
 {
-  "cpu": [max5m, max1h, max24h],
-  "mem": [max5m, max1h, max24h]
+  "cpu": [max1m, max5m, max1h, max24h],
+  "mem": [max1m, max5m, max1h, max24h]
 }
 ```
+
+The endpoint accepts an optional `output_format` query parameter. When set to
+`html` it returns a simple table for each VM; otherwise JSON is returned.
 
 Set the polling interval (seconds, decimals allowed) with `READ_TICKER_TIME_SEC` and the server port with
 `STATS_PORT` in the environment. Each instance must define `VM_NAME`.

--- a/internal/app/summary.go
+++ b/internal/app/summary.go
@@ -9,8 +9,8 @@ type dataPoint struct {
 }
 
 type Stats struct {
-	CPU [3]float32 `json:"cpu"`
-	Mem [3]uint32  `json:"mem"`
+	CPU [4]float32 `json:"cpu"`
+	Mem [4]uint32  `json:"mem"`
 }
 
 type NodeStats struct {
@@ -22,7 +22,7 @@ func computeSummary(points []dataPoint, now time.Time) Stats {
 	var s Stats
 	for _, p := range points {
 		delta := now.Sub(p.ts)
-		if delta <= 5*time.Minute {
+		if delta <= time.Minute {
 			if p.cpu > s.CPU[0] {
 				s.CPU[0] = p.cpu
 			}
@@ -30,7 +30,7 @@ func computeSummary(points []dataPoint, now time.Time) Stats {
 				s.Mem[0] = p.mem
 			}
 		}
-		if delta <= time.Hour {
+		if delta <= 5*time.Minute {
 			if p.cpu > s.CPU[1] {
 				s.CPU[1] = p.cpu
 			}
@@ -38,12 +38,20 @@ func computeSummary(points []dataPoint, now time.Time) Stats {
 				s.Mem[1] = p.mem
 			}
 		}
-		if delta <= 24*time.Hour {
+		if delta <= time.Hour {
 			if p.cpu > s.CPU[2] {
 				s.CPU[2] = p.cpu
 			}
 			if p.mem > s.Mem[2] {
 				s.Mem[2] = p.mem
+			}
+		}
+		if delta <= 24*time.Hour {
+			if p.cpu > s.CPU[3] {
+				s.CPU[3] = p.cpu
+			}
+			if p.mem > s.Mem[3] {
+				s.Mem[3] = p.mem
 			}
 		}
 	}

--- a/internal/app/summary_test.go
+++ b/internal/app/summary_test.go
@@ -15,8 +15,8 @@ func TestComputeSummary(t *testing.T) {
 	}
 	got := computeSummary(points, now)
 	want := Stats{
-		CPU: [3]float32{10, 50, 90},
-		Mem: [3]uint32{100, 300, 400},
+		CPU: [4]float32{0, 10, 50, 90},
+		Mem: [4]uint32{0, 100, 300, 400},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("computeSummary() = %v, want %v", got, want)


### PR DESCRIPTION
## Summary
- track 1-minute CPU and RAM peaks alongside existing intervals
- support `output_format=html` on `/stats` to render per-VM tables
- document new 1m interval and HTML option

## Testing
- `go build -v ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b7285c4030832cb8be2a84cf58ceb6